### PR TITLE
Migrate from master-slave terminology

### DIFF
--- a/myenv/bin/enhancer.py
+++ b/myenv/bin/enhancer.py
@@ -20,8 +20,8 @@ import sys
 
 
 class Enhance(Frame):
-    def __init__(self, master, image, name, enhancer, lo, hi):
-        Frame.__init__(self, master)
+    def __init__(self, main, image, name, enhancer, lo, hi):
+        Frame.__init__(self, main)
 
         # set up the image
         self.tkim = ImageTk.PhotoImage(image.mode, image.size)

--- a/myenv/bin/painter.py
+++ b/myenv/bin/painter.py
@@ -22,8 +22,8 @@ import sys
 
 
 class PaintCanvas(Canvas):
-    def __init__(self, master, image):
-        Canvas.__init__(self, master, width=image.size[0], height=image.size[1])
+    def __init__(self, main, image):
+        Canvas.__init__(self, main, width=image.size[0], height=image.size[1])
 
         # fill the canvas
         self.tile = {}

--- a/myenv/bin/player.py
+++ b/myenv/bin/player.py
@@ -20,7 +20,7 @@ import sys
 
 class UI(Label):
 
-    def __init__(self, master, im):
+    def __init__(self, main, im):
         if isinstance(im, list):
             # list of images
             self.im = im[1:]
@@ -34,7 +34,7 @@ class UI(Label):
         else:
             self.image = ImageTk.PhotoImage(im)
 
-        Label.__init__(self, master, image=self.image, bg="black", bd=0)
+        Label.__init__(self, main, image=self.image, bg="black", bd=0)
 
         self.update()
 

--- a/myenv/bin/thresholder.py
+++ b/myenv/bin/thresholder.py
@@ -20,8 +20,8 @@ import sys
 
 
 class UI(Frame):
-    def __init__(self, master, im, value=128):
-        Frame.__init__(self, master)
+    def __init__(self, main, im, value=128):
+        Frame.__init__(self, main)
 
         self.image = im
         self.value = value

--- a/myenv/bin/viewer.py
+++ b/myenv/bin/viewer.py
@@ -19,17 +19,17 @@ from PIL import Image, ImageTk
 
 class UI(Label):
 
-    def __init__(self, master, im):
+    def __init__(self, main, im):
 
         if im.mode == "1":
             # bitmap image
             self.image = ImageTk.BitmapImage(im, foreground="white")
-            Label.__init__(self, master, image=self.image, bg="black", bd=0)
+            Label.__init__(self, main, image=self.image, bg="black", bd=0)
 
         else:
             # photo image
             self.image = ImageTk.PhotoImage(im)
-            Label.__init__(self, master, image=self.image, bd=0)
+            Label.__init__(self, main, image=self.image, bd=0)
 
 #
 # script interface


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.